### PR TITLE
fix for <BF-S2021-75>

### DIFF
--- a/src/app/pages/tracker-page/tracker-page.component.ts
+++ b/src/app/pages/tracker-page/tracker-page.component.ts
@@ -26,7 +26,7 @@ export class TrackerPageComponent implements OnInit {
   BULLETED_INSTRUCTIONS = [
     'For each food item select the appropriate answer',
     'If your baby consumed more than the recommended amount select the up arrow',
-    'If your baby consumed the recommended amount select the check mark',
+    'If your baby consumed the recommended amount select the equal sign',
     'If your baby consumed less than the recommended amount select the down arrow',
     'Click the submit button when finished.'
   ];


### PR DESCRIPTION
change the text in the parent portal, tracking tab - where the instructions say select the “check mark” change text to "equal sign"