### PR TITLE
Bug fix in Tracking History for Clinician Portal

### DIFF
--- a/src/app/pages/clinic-tracker-history/clinic-tracker-history.component.html
+++ b/src/app/pages/clinic-tracker-history/clinic-tracker-history.component.html
@@ -14,21 +14,21 @@
 <div class="tracker-container">
   <div class="trackeritem-container">
     <mat-card class="tracker-card">
-      <h2 matDialogTitle class="GoalTitle" i18n>Goal Setting</h2>
+      <h2 matDialogTitle class="GoalTitle">Goal Setting</h2>
       <ul>
-        <li class="GoalList" i18n>
+        <li class="GoalList">
           If your baby consumed above or below the recommended amount, pick 1
           food group to improve this week.
         </li>
-        <li class="GoalList" i18n>
+        <li class="GoalList">
           After age 6 months, your baby should eat a variety of healthy foods
           because good eating habits start early.
         </li>
-        <li class="GoalList" i18n>
+        <li class="GoalList">
           If your baby does not like a food, try again another day. It can take
           up to 15 times before they accept a new food.
         </li>
-        <li class="GoalList" i18n>
+        <li class="GoalList">
           Review the food groups in the "Recommendations" tab to help you plan
           your baby's menu for this week.
         </li>


### PR DESCRIPTION
Removed i18n Tags in the clinician portal tracker history page. These tags were implemented due to use needing to add a goal text box in the tracker history page as one of our sprints. I kept on using the same branch when I shouldve branched out from master.