### PR TITLE
Fixed Redirection from middle of the page to the top of the page.

### DIFF
--- a/src/app/pages/questionnaire-page/questionnaire-page.component.ts
+++ b/src/app/pages/questionnaire-page/questionnaire-page.component.ts
@@ -143,10 +143,10 @@ export class QuestionnairePageComponent implements OnInit {
               }
 
             this.questService.submitQuestionnaire(this.id).subscribe((data: Questionnaire) => {
-            this.router.navigateByUrl('/');
             const dialogRef = this.successDialog.open(ErrorDialogPopupComponent);
             dialogRef.componentInstance.title = this.translate.instant('Submitted Successfully');
             dialogRef.componentInstance.message = this.translate.instant('The questionnaire has been sent to the issuer');
+            dialogRef.afterClosed().subscribe(() => this.router.navigateByUrl('/'));
             this.submitting = false;
             }, (error: HttpErrorResponse) => this.handleSubmissionError(error));
 

--- a/src/app/pages/tracker-page/tracker-page.component.ts
+++ b/src/app/pages/tracker-page/tracker-page.component.ts
@@ -84,12 +84,16 @@ export class TrackerPageComponent implements OnInit {
                                                         this.age,
                                                         formatDate(new Date(), 'MM/dd/yyyy', 'en'),
                                                         this.trackerItems);
-
       this.trackerResponseService.submitTracker(this.trackerResponse).subscribe(() => {
         const dialogRef = this.successDialog.open(ErrorDialogPopupComponent);
         dialogRef.componentInstance.title = this.translate.instant('Submitted Successfully');
         dialogRef.componentInstance.message = this.translate.instant('Your submission has been recorded');
-        this.router.navigate(['parent/tracker-history']);
+        // Created this afterclosed code snipet so users can see they are done with the tracking AND THEN redirect them to the proper page
+        // This snippet fixes the page bug that doesnt scroll all the way to the top.
+        // Created by Alberto Canete and Henry Labrada
+        dialogRef.afterClosed().subscribe(() => {
+          this.router.navigate(['parent/tracker-history']);
+        });
       }, (error: HttpErrorResponse) => {
         const  dialogRef  = this.submissionErrorDialog.open(ErrorDialogPopupComponent);
         dialogRef.componentInstance.title = this.translate.instant('Submission Error');
@@ -103,7 +107,6 @@ export class TrackerPageComponent implements OnInit {
       dialogRef.componentInstance.message = this.translate.instant('Please ensure all required fields are completed');
     }
   }
-
   private getAllResults() {
      const list: Observable<Description[]> = this.foodDescriptionService.getAllFoodItems();
      list.subscribe(m => {


### PR DESCRIPTION
Fixed an issue on the tracker and questionnaire page after submission the page anchors towards the middle. We realize the pop up box blocks the scrolling of the page so Henry and I decided to try to find  a way to redirect us after closing the dialog box.